### PR TITLE
Add dependabot to the repo

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "weekly"
+    default_assignees:
+      - "deanwilson"
+    default_reviewers:
+    - "deanwilson"


### PR DESCRIPTION
I'd like to track my depencencies using dependabot and I'd rather configure it
via the repo than the dependabot webpage